### PR TITLE
Fix: invalid plasma.cancel return statement

### DIFF
--- a/lib/plasma.dart
+++ b/lib/plasma.dart
@@ -147,7 +147,6 @@ Future<void> _cancel() async {
         print('${red('Error!')} Fuse entry can not be cancelled yet');
         gotError = true;
       }
-      return;
     }
     pageIndex++;
     fusions = await znnClient.embedded.plasma


### PR DESCRIPTION
This was preventing the CLI from reaching code to cancel fuses.